### PR TITLE
Fixed pin mux configuration for our custom board.

### DIFF
--- a/include/pinmux.h
+++ b/include/pinmux.h
@@ -1,7 +1,10 @@
 //*****************************************************************************
+// pinmux.h
 //
-// Copyright (C) 2014 Texas Instruments Incorporated - http://www.ti.com/ 
-// 
+// configure the device pins for different signals
+//
+// Copyright (c) 2016, Texas Instruments Incorporated - http://www.ti.com/ 
+// All rights reserved.
 // 
 //  Redistribution and use in source and binary forms, with or without 
 //  modification, are permitted provided that the following conditions 
@@ -33,15 +36,14 @@
 //
 //*****************************************************************************
 
-// This file was automatically generated on 7/21/2014 at 3:06:20 PM
-// by TI PinMux version 3.0.334
+// This file was automatically generated on 2/13/2017 at 10:08:56 AM
+// by TI PinMux version 4.0.1482 
 //
 //*****************************************************************************
 
-#ifndef __PINMUX_H__
-#define __PINMUX_H__
+#ifndef __PIN_MUX_CONFIG_H__
+#define __PIN_MUX_CONFIG_H__
 
 extern void PinMuxConfig(void);
 
-#endif //  __PINMUX_H__
-
+#endif //  __PIN_MUX_CONFIG_H__

--- a/src/rom_pinmux.c
+++ b/src/rom_pinmux.c
@@ -1,5 +1,5 @@
 //*****************************************************************************
-// pinmux.c
+// rom_pinmux.c
 //
 // configure the device pins for different signals
 //
@@ -36,7 +36,7 @@
 //
 //*****************************************************************************
 
-// This file was automatically generated on 2/13/2017 at 10:28:44 AM
+// This file was automatically generated on 2/13/2017 at 10:29:40 AM
 // by TI PinMux version 4.0.1482 
 //
 //*****************************************************************************
@@ -48,6 +48,8 @@
 #include "pin.h"
 #include "gpio.h"
 #include "prcm.h"
+#include "rom.h"
+#include "rom_map.h"
 //*****************************************************************************
 void PinMuxConfig(void)
 {
@@ -56,113 +58,113 @@ void PinMuxConfig(void)
     //
     // Set unused pins to PIN_MODE_0 with the exception of JTAG pins 16,17,19,20
     //
-    PinModeSet(PIN_21, PIN_MODE_0);
+    MAP_PinModeSet(PIN_21, PIN_MODE_0);
     
     //
     // Enable Peripheral Clocks 
     //
-    PRCMPeripheralClkEnable(PRCM_GPIOA0, PRCM_RUN_MODE_CLK);
-    PRCMPeripheralClkEnable(PRCM_GPIOA1, PRCM_RUN_MODE_CLK);
-    PRCMPeripheralClkEnable(PRCM_GPIOA2, PRCM_RUN_MODE_CLK);
-    PRCMPeripheralClkEnable(PRCM_GPIOA3, PRCM_RUN_MODE_CLK);
-    PRCMPeripheralClkEnable(PRCM_SDHOST, PRCM_RUN_MODE_CLK);
-    PRCMPeripheralClkEnable(PRCM_UARTA0, PRCM_RUN_MODE_CLK);
-    PRCMPeripheralClkEnable(PRCM_UARTA1, PRCM_RUN_MODE_CLK);
-    PRCMPeripheralClkEnable(PRCM_I2CA0, PRCM_RUN_MODE_CLK);
+    MAP_PRCMPeripheralClkEnable(PRCM_GPIOA0, PRCM_RUN_MODE_CLK);
+    MAP_PRCMPeripheralClkEnable(PRCM_GPIOA1, PRCM_RUN_MODE_CLK);
+    MAP_PRCMPeripheralClkEnable(PRCM_GPIOA2, PRCM_RUN_MODE_CLK);
+    MAP_PRCMPeripheralClkEnable(PRCM_GPIOA3, PRCM_RUN_MODE_CLK);
+    MAP_PRCMPeripheralClkEnable(PRCM_SDHOST, PRCM_RUN_MODE_CLK);
+    MAP_PRCMPeripheralClkEnable(PRCM_UARTA0, PRCM_RUN_MODE_CLK);
+    MAP_PRCMPeripheralClkEnable(PRCM_UARTA1, PRCM_RUN_MODE_CLK);
+    MAP_PRCMPeripheralClkEnable(PRCM_I2CA0, PRCM_RUN_MODE_CLK);
     //
     // Configure PIN_50 for GPIO Input
     //
-    PinTypeGPIO(PIN_50, PIN_MODE_0, false);
-    GPIODirModeSet(GPIOA0_BASE, 0x1, GPIO_DIR_MODE_IN);
+    MAP_PinTypeGPIO(PIN_50, PIN_MODE_0, false);
+    MAP_GPIODirModeSet(GPIOA0_BASE, 0x1, GPIO_DIR_MODE_IN);
     //
     // Configure PIN_58 for GPIO Input
     //
-    PinTypeGPIO(PIN_58, PIN_MODE_0, false);
-    GPIODirModeSet(GPIOA0_BASE, 0x8, GPIO_DIR_MODE_IN);
+    MAP_PinTypeGPIO(PIN_58, PIN_MODE_0, false);
+    MAP_GPIODirModeSet(GPIOA0_BASE, 0x8, GPIO_DIR_MODE_IN);
     //
     // Configure PIN_59 for GPIO Input
     //
-    PinTypeGPIO(PIN_59, PIN_MODE_0, false);
-    GPIODirModeSet(GPIOA0_BASE, 0x10, GPIO_DIR_MODE_IN);
+    MAP_PinTypeGPIO(PIN_59, PIN_MODE_0, false);
+    MAP_GPIODirModeSet(GPIOA0_BASE, 0x10, GPIO_DIR_MODE_IN);
     //
     // Configure PIN_60 for GPIO Output
     //
-    PinTypeGPIO(PIN_60, PIN_MODE_0, false);
-    GPIODirModeSet(GPIOA0_BASE, 0x20, GPIO_DIR_MODE_OUT);
+    MAP_PinTypeGPIO(PIN_60, PIN_MODE_0, false);
+    MAP_GPIODirModeSet(GPIOA0_BASE, 0x20, GPIO_DIR_MODE_OUT);
     //
     // Configure PIN_61 for GPIO Output
     //
-    PinTypeGPIO(PIN_61, PIN_MODE_0, false);
-    GPIODirModeSet(GPIOA0_BASE, 0x40, GPIO_DIR_MODE_OUT);
+    MAP_PinTypeGPIO(PIN_61, PIN_MODE_0, false);
+    MAP_GPIODirModeSet(GPIOA0_BASE, 0x40, GPIO_DIR_MODE_OUT);
     //
     // Configure PIN_62 for GPIO Output
     //
-    PinTypeGPIO(PIN_62, PIN_MODE_0, false);
-    GPIODirModeSet(GPIOA0_BASE, 0x80, GPIO_DIR_MODE_OUT);
+    MAP_PinTypeGPIO(PIN_62, PIN_MODE_0, false);
+    MAP_GPIODirModeSet(GPIOA0_BASE, 0x80, GPIO_DIR_MODE_OUT);
     //
     // Configure PIN_63 for GPIO Output
     //
-    PinTypeGPIO(PIN_63, PIN_MODE_0, false);
-    GPIODirModeSet(GPIOA1_BASE, 0x1, GPIO_DIR_MODE_OUT);
+    MAP_PinTypeGPIO(PIN_63, PIN_MODE_0, false);
+    MAP_GPIODirModeSet(GPIOA1_BASE, 0x1, GPIO_DIR_MODE_OUT);
     //
     // Configure PIN_64 for GPIO Output
     //
-    PinTypeGPIO(PIN_64, PIN_MODE_0, false);
-    GPIODirModeSet(GPIOA1_BASE, 0x2, GPIO_DIR_MODE_OUT);
+    MAP_PinTypeGPIO(PIN_64, PIN_MODE_0, false);
+    MAP_GPIODirModeSet(GPIOA1_BASE, 0x2, GPIO_DIR_MODE_OUT);
     //
     // Configure PIN_01 for GPIO Output
     //
-    PinTypeGPIO(PIN_01, PIN_MODE_0, false);
-    GPIODirModeSet(GPIOA1_BASE, 0x4, GPIO_DIR_MODE_OUT);
+    MAP_PinTypeGPIO(PIN_01, PIN_MODE_0, false);
+    MAP_GPIODirModeSet(GPIOA1_BASE, 0x4, GPIO_DIR_MODE_OUT);
     //
     // Configure PIN_15 for GPIO Output
     //
-    PinTypeGPIO(PIN_15, PIN_MODE_0, false);
-    GPIODirModeSet(GPIOA2_BASE, 0x40, GPIO_DIR_MODE_OUT);
+    MAP_PinTypeGPIO(PIN_15, PIN_MODE_0, false);
+    MAP_GPIODirModeSet(GPIOA2_BASE, 0x40, GPIO_DIR_MODE_OUT);
     //
     // Configure PIN_18 for GPIO Input
     //
-    PinTypeGPIO(PIN_18, PIN_MODE_0, false);
-    GPIODirModeSet(GPIOA3_BASE, 0x10, GPIO_DIR_MODE_IN);
+    MAP_PinTypeGPIO(PIN_18, PIN_MODE_0, false);
+    MAP_GPIODirModeSet(GPIOA3_BASE, 0x10, GPIO_DIR_MODE_IN);
     //
     // Configure PIN_53 for GPIO Input
     //
-    PinTypeGPIO(PIN_53, PIN_MODE_0, false);
-    GPIODirModeSet(GPIOA3_BASE, 0x40, GPIO_DIR_MODE_IN);
+    MAP_PinTypeGPIO(PIN_53, PIN_MODE_0, false);
+    MAP_GPIODirModeSet(GPIOA3_BASE, 0x40, GPIO_DIR_MODE_IN);
     //
     // Configure PIN_06 for SDHost0 SDCARD_DATA
     //
-    PinTypeSDHost(PIN_06, PIN_MODE_8);
+    MAP_PinTypeSDHost(PIN_06, PIN_MODE_8);
     //
     // Configure PIN_07 for SDHost0 SDCARD_CLK
     //
-    PinTypeSDHost(PIN_07, PIN_MODE_8);
+    MAP_PinTypeSDHost(PIN_07, PIN_MODE_8);
     //
     // Configure PIN_08 for SDHost0 SDCARD_CMD
     //
-    PinTypeSDHost(PIN_08, PIN_MODE_8);
+    MAP_PinTypeSDHost(PIN_08, PIN_MODE_8);
     //
     // Configure PIN_03 for UART0 UART0_TX
     //
-    PinTypeUART(PIN_03, PIN_MODE_7);
+    MAP_PinTypeUART(PIN_03, PIN_MODE_7);
     //
     // Configure PIN_04 for UART0 UART0_RX
     //
-    PinTypeUART(PIN_04, PIN_MODE_7);
+    MAP_PinTypeUART(PIN_04, PIN_MODE_7);
     //
     // Configure PIN_55 for UART1 UART1_TX
     //
-    PinTypeUART(PIN_55, PIN_MODE_6);
+    MAP_PinTypeUART(PIN_55, PIN_MODE_6);
     //
     // Configure PIN_57 for UART1 UART1_RX
     //
-    PinTypeUART(PIN_57, PIN_MODE_6);
+    MAP_PinTypeUART(PIN_57, PIN_MODE_6);
     //
     // Configure PIN_05 for I2C0 I2C_SCL
     //
-    PinTypeI2C(PIN_05, PIN_MODE_5);
+    MAP_PinTypeI2C(PIN_05, PIN_MODE_5);
     //
     // Configure PIN_02 for I2C0 I2C_SDA
     //
-    PinTypeI2C(PIN_02, PIN_MODE_1);
+    MAP_PinTypeI2C(PIN_02, PIN_MODE_1);
 }


### PR DESCRIPTION
This commit includes modifications to the pin mux configuration files
in order to support the pinout on our custom AirU boards. Note this
pin muxing will not work natively with examples for the TI LaunchPad
board.