### PR TITLE
Adds an initial driver implementation for OPT3001

### DIFF
--- a/include/OPT3001.h
+++ b/include/OPT3001.h
@@ -1,0 +1,47 @@
+#include <stdint.h>
+
+#ifndef __OPT3001_H__
+#define __OPT3001_H__
+
+//*****************************************************************************
+// If building with a C++ compiler, make all of the definitions in this header
+// have a C binding.
+//*****************************************************************************
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#define OPT3001_DEV_ADDR 0x44 // Addr Pin tied to GND
+#define OPT3001_CONV_TIME 850 // milliseconds
+
+// Register Map
+#define OPT3001_RESULT_REG   0x00 // Result Register Address
+#define OPT3001_CONFIG_REG   0x01 // Configuration Register Address
+#define OPT3001_LOW_LIM_REG  0x02 // Low Limit Register Address
+#define OPT3001_HIGH_LIM_REG 0x03 // High Limit Register Address
+#define OPT3001_MANU_ID_REG  0x7E // Manufacturer ID Register Address
+#define OPT3001_DEV_ID_REG   0x7F // Device ID Register Address
+
+#define OPT3001_MODE_SHUTDOWN_MASK 0xF9FF // Shutdown Mode - Bits 10:9 [0, 0]
+#define OPT3001_MODE_SINGLE_MASK   0xFBFF // Single-shot Mode - Bits 10:9 [0, 1]
+#define OPT3001_MODE_CONTIN_MASK   0xFDFF // Continuous Mode - Bits 10:9 [1, 0]
+
+void ConfigureOPT3001Mode(void);
+float GetOPT3001Result(void);
+uint16_t GetOPT3001Configuration(void);
+float GetOPT3001LowLimit(void);
+float GetOPT3001HighLimit(void);
+uint16_t GetOPT3001ManufacturerID(void);
+uint16_t GetOPT3001DeviceID(void);
+
+static float ConvertResultToLux(uint16_t);
+
+//*****************************************************************************
+// Mark the end of the C bindings section for C++ compilers.
+//*****************************************************************************
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __OPT3001_H__ */

--- a/src/OPT3001.c
+++ b/src/OPT3001.c
@@ -1,0 +1,95 @@
+// Common Interface includes
+#include "i2c_if.h"
+
+// Application includes
+#include "OPT3001.h"
+
+static float ConvertResultToLux(uint16_t res)
+{
+	uint16_t frac = res & 0x0FFF; // Mask the lower 12 bits for the fraction
+	uint8_t exp = (res >> 12) & 0x000F; // Mask the upper 4 bits for the exponent
+
+	// This equation is specified in (3) in the datasheet.
+	float lux = 0.01 * (1 << exp) * frac;
+
+	return lux;
+}
+
+float GetOPT3001Result(void)
+{
+	uint8_t regaddr = OPT3001_RESULT_REG;
+	uint8_t regval[2];
+
+	I2C_IF_ReadFrom(OPT3001_DEV_ADDR, &regaddr, 1, regval, 2);
+
+	// TODO: Check for error conditions (overflow, etc..)
+
+	uint16_t res = (regval[0] << 8) | regval[1];
+	return ConvertResultToLux(res);
+}
+
+void ConfigureOPT3001Mode(void)
+{
+	uint16_t config = GetOPT3001Configuration();
+
+	uint8_t data[2];
+	data[0] = OPT3001_CONFIG_REG;
+
+	uint16_t mode_mask = OPT3001_MODE_CONTIN_MASK;
+
+	uint16_t mask = mode_mask;
+	data[1] = config & mask;
+
+	I2C_IF_Write(OPT3001_DEV_ADDR, data, 2, 1);
+}
+
+uint16_t GetOPT3001Configuration(void)
+{
+	// Get the current device mode configuration
+	uint8_t regaddr = OPT3001_CONFIG_REG;
+	uint8_t regval[2];
+	I2C_IF_ReadFrom(OPT3001_DEV_ADDR, &regaddr, 1, regval, 2);
+	// TODO: Handle error case here.
+
+	uint16_t config = (regval[0] << 8) | regval[1];
+
+	return config;
+}
+
+float GetOPT3001LowLimit(void)
+{
+	// TODO: Implement me!
+	uint16_t res = 0;
+
+	return ConvertResultToLux(res);
+}
+
+float GetOPT3001HighLimit(void)
+{
+	// TODO: Implement me!
+	uint16_t res = 0;
+
+	return ConvertResultToLux(res);
+}
+
+uint16_t GetOPT3001ManufacturerID(void)
+{
+	uint8_t regaddr = OPT3001_MANU_ID_REG;
+	uint8_t regval[2];
+
+	I2C_IF_ReadFrom(OPT3001_DEV_ADDR, &regaddr, 1, regval, 2);
+
+	uint16_t id = (regval[0] << 8) | regval[1];
+	return id;
+}
+
+uint16_t GetOPT3001DeviceID(void)
+{
+	uint8_t regaddr = OPT3001_DEV_ID_REG;
+	uint8_t regval[2];
+
+	I2C_IF_ReadFrom(OPT3001_DEV_ADDR, &regaddr, 1, regval, 2);
+
+	uint16_t id = (regval[0] << 8) | regval[1];
+	return id;
+}


### PR DESCRIPTION
This commit adds a preliminary driver for TI's OPT3001 ambient
light sensor. All functions implemented here have been tested.
Note that this release is a preliminary release, and does not
include error checking and I2C recovery methods. These should
be added in the near future.